### PR TITLE
Suggestion to implement strict identifiers for nodes to improve clarity

### DIFF
--- a/api/api.hpp
+++ b/api/api.hpp
@@ -30,7 +30,12 @@ namespace PluginAPI {
 
     struct Property {
 
-        enum TYPE { PRIMARY_COLOR, SECONDARY_COLOR, THICKNESS };
+        enum TYPE { 
+            PRIMARY_COLOR = 0, 
+            SECONDARY_COLOR = 1, 
+            THICKNESS = 2 
+        };
+        
         enum DISPLAY_TYPE { COLOR_PICKER, SLIDER, INPUTBOX, CHECKBOX };
 
         DISPLAY_TYPE display_type;


### PR DESCRIPTION
It is not a good idea to rely on implicit enum values since plugin developer should be able to add custom properties. Suggestion is to implement strict IDs to ensure that the rest of IDs is free.